### PR TITLE
Use icons for role badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,11 +186,11 @@
   function setBadge(rec, role){
     if(!rec?.badge) return;
     if(role==='OFF'){
-      rec.badge.textContent='OFF';
+      rec.badge.textContent='⚔️';
       rec.badge.className='badge off';
       rec.badge.style.display='block';
     } else if(role==='DEF'){
-      rec.badge.textContent='DEF';
+      rec.badge.textContent='🛡️';
       rec.badge.className='badge def';
       rec.badge.style.display='block';
     } else {


### PR DESCRIPTION
## Summary
- show a sword icon for offensive role badges
- show a shield icon for defensive role badges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995f1bc6ec83218628105c46251d98