### PR TITLE
feat: add selectable player count

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,11 @@
       text-transform:uppercase; letter-spacing:.5px;
     }
     button:active{ transform:translateY(1px); box-shadow:0 2px 0 #0a0a12, inset 0 -2px 0 rgba(0,0,0,.25); }
+    select{
+      border:2px solid #3a3e55; border-radius:6px; padding:10px 12px;
+      background:#2a2e44; color:#f3f4e8; font-size:10px;
+      text-transform:uppercase; letter-spacing:.5px;
+    }
     .ghost{ background:transparent; border-style:dashed; color:var(--muted) }
 
     .arena{
@@ -112,14 +117,19 @@
 <div class="app">
   <header>
     <h1>🎮 TeamTap v1.2</h1>
-		<div class="sub">Have <b>10 players</b> place their fingers on the screen — the system will auto-assign <b style="color:var(--OFF)">Offense</b> / <b style="color:var(--DEF)">Defense</b></div>
+    <div id="instructions" class="sub">Have <b>10 players</b> place their fingers on the screen — the system will auto-assign <b style="color:var(--OFF)">Offense</b> / <b style="color:var(--DEF)">Defense</b></div>
     <div class="controls">
+      <select id="selPlayers">
+        <option value="10" selected>10 Players</option>
+        <option value="8">8 Players</option>
+        <option value="6">6 Players</option>
+      </select>
       <button id="btnMode">Mode: Touch</button>
       <button id="btnAssign" class="ghost" style="display:none;">Assign Teams</button>
       <button id="btnClear">Clear</button>
       <button id="btnSim" class="ghost">Simulate 10 (Test)</button>
-    </div>
-  </header>
+      </div>
+    </header>
 
   <div id="arena" class="arena">
     <div id="hint" class="hint">
@@ -134,7 +144,7 @@
   </div>
 
   <div class="panel">
-    <div class="stat">Current Tokens/Fingers: <span id="count" class="counter">0</span> / 10</div>
+    <div class="stat">Current Tokens/Fingers: <span id="count" class="counter">0</span> / <span id="maxCount">10</span></div>
     <div class="stat" id="status">Mode: Touch — Waiting…</div>
   </div>
 </div>
@@ -157,12 +167,16 @@
   const btnMode = document.getElementById('btnMode');
   const btnAssign = document.getElementById('btnAssign');
   const toast   = document.getElementById('toast');
+  const selPlayers = document.getElementById('selPlayers');
+  const instructionsEl = document.getElementById('instructions');
+  const maxCountEl = document.getElementById('maxCount');
 
   // Mode state
   let mode = 'touch'; // 'touch' | 'tap'
   const touches = new Map(); // touchId -> rec
   let splitDone = false;
   let nextLabel = 1; // for Tap Tokens numbering
+  let maxPlayers = parseInt(selPlayers.value, 10);
 
   // utils
   function getLocalXY(clientX, clientY){
@@ -200,18 +214,26 @@
     }
   }
 
+  function updateInstructions(){
+    instructionsEl.innerHTML = `Have <b>${maxPlayers} players</b> place their fingers on the screen — the system will auto-assign <b style="color:var(--OFF)">Offense</b> / <b style="color:var(--DEF)">Defense</b>`;
+    hint.innerHTML = `<b>Touch Mode:</b> Place ${maxPlayers} fingers at the same time.<br/><b>Tap Tokens:</b> Tap ${maxPlayers} times to place tokens; tap a token to remove.`;
+    maxCountEl.textContent = maxPlayers;
+    btnSim.textContent = `Simulate ${maxPlayers} (Test)`;
+  }
+
   function updateCountUI(){
     const n = touches.size;
     countEl.textContent = n;
+    maxCountEl.textContent = maxPlayers;
     hint.style.display = n===0 ? 'block':'none';
     if(mode==='touch'){
-      if(n<10){ statusEl.textContent='Mode: Touch — Waiting for 10 fingers…'; banner.style.display='none'; }
-      else if(n===10){ statusEl.textContent = splitDone ? 'Teams assigned…' : '10 fingers — assigning teams…'; }
-      else { statusEl.textContent='Mode: Touch — More than 10 fingers, keep only 10'; }
+      if(n<maxPlayers){ statusEl.textContent=`Mode: Touch — Waiting for ${maxPlayers} fingers…`; banner.style.display='none'; }
+      else if(n===maxPlayers){ statusEl.textContent = splitDone ? 'Teams assigned…' : `${maxPlayers} fingers — assigning teams…`; }
+      else { statusEl.textContent=`Mode: Touch — More than ${maxPlayers} fingers, keep only ${maxPlayers}`; }
     } else {
-      statusEl.textContent = `Mode: Tap Tokens — Tap to add/remove (${n}/10)`;
-      btnAssign.style.display = (n===10 && !splitDone) ? 'inline-block' : 'none';
-      if(n<10) banner.style.display='none';
+      statusEl.textContent = `Mode: Tap Tokens — Tap to add/remove (${n}/${maxPlayers})`;
+      btnAssign.style.display = (n===maxPlayers && !splitDone) ? 'inline-block' : 'none';
+      if(n<maxPlayers) banner.style.display='none';
     }
   }
 
@@ -224,8 +246,9 @@
 
   function assignTeamsFrom(records){
     const order = shuffle(records);
-    const OFF = order.slice(0,5);
-    const DEF = order.slice(5,10);
+    const half = maxPlayers / 2;
+    const OFF = order.slice(0,half);
+    const DEF = order.slice(half,maxPlayers);
     OFF.forEach(t => { t.role='OFF'; t.el.style.background = OFF_COL; setBadge(t,'OFF'); });
     DEF.forEach(t => { t.role='DEF'; t.el.style.background = DEF_COL; setBadge(t,'DEF'); });
     countOffEl.textContent = OFF.length;
@@ -241,7 +264,7 @@
     if(mode!=='touch') return;
     ev.preventDefault();
     for(const t of ev.changedTouches){
-      if(touches.size >= 10) continue;
+      if(touches.size >= maxPlayers) continue;
       if(touches.has(t.identifier)) continue;
       const { x, y } = getLocalXY(t.clientX, t.clientY);
       const label = (touches.size+1);
@@ -249,7 +272,7 @@
       touches.set(t.identifier, { ...rec, idx: label-1, role: null });
     }
     updateCountUI();
-    if(touches.size===10 && !splitDone){
+    if(touches.size===maxPlayers && !splitDone){
       assignTeamsFrom(Array.from(touches.values()));
     }
   }
@@ -274,8 +297,8 @@
   // ==== Tap Tokens Mode ====
   function onArenaClick(e){
     if(mode!=='tap') return;
-    // add token if < 10
-    if(touches.size >= 10){ showToast('Already 10 tokens. Tap a token to remove.'); return; }
+    // add token if < maxPlayers
+    if(touches.size >= maxPlayers){ showToast(`Already ${maxPlayers} tokens. Tap a token to remove.`); return; }
     const { x, y } = getLocalXY(e.clientX, e.clientY);
     const rec = createFinger(x,y,nextLabel++);
     // store with a generated id
@@ -304,11 +327,11 @@
   });
 
   btnSim.addEventListener('click', ()=>{
-    // works for either mode: just place 10 tokens at random
+    // works for either mode: just place maxPlayers tokens at random
     btnClear.click();
     const rect = arena.getBoundingClientRect();
     const pad = 90;
-    for(let i=0;i<10;i++){
+    for(let i=0;i<maxPlayers;i++){
       const x = Math.random()*(rect.width-pad*2)+pad;
       const y = Math.random()*(rect.height-pad*2)+pad;
       const rec = createFinger(x,y,i+1);
@@ -324,15 +347,15 @@
     if(mode==='touch'){
       mode='tap';
       btnMode.textContent='Mode: Tap Tokens';
-      btnAssign.style.display = (touches.size===10 && !splitDone) ? 'inline-block':'none';
-      statusEl.textContent='Mode: Tap Tokens — Tap to add/remove (0/10)';
+      btnAssign.style.display = (touches.size===maxPlayers && !splitDone) ? 'inline-block':'none';
+      statusEl.textContent=`Mode: Tap Tokens — Tap to add/remove (0/${maxPlayers})`;
       showToast('Tap anywhere to add tokens. Tap a token to remove.');
     } else {
       mode='touch';
       btnMode.textContent='Mode: Touch';
       btnAssign.style.display='none';
       statusEl.textContent='Mode: Touch — Waiting…';
-      showToast('Place up to 10 fingers at once.');
+      showToast(`Place up to ${maxPlayers} fingers at once.`);
     }
     // clearing is simplest to avoid mixed data
     touches.forEach(t => t.el.remove());
@@ -344,9 +367,15 @@
 
   btnAssign.addEventListener('click', ()=>{
     if(mode!=='tap') return;
-    if(touches.size !== 10){ showToast('Need exactly 10 tokens to assign.'); return; }
+    if(touches.size !== maxPlayers){ showToast(`Need exactly ${maxPlayers} tokens to assign.`); return; }
     if(splitDone) return;
     assignTeamsFrom(Array.from(touches.values()));
+  });
+
+  selPlayers.addEventListener('change', () => {
+    maxPlayers = parseInt(selPlayers.value, 10);
+    updateInstructions();
+    btnClear.click();
   });
 
   // ==== Listeners ====
@@ -371,6 +400,7 @@
 
   // init
   (function init(){
+    updateInstructions();
     updateCountUI();
   })();
 </script>


### PR DESCRIPTION
## Summary
- add dropdown to choose 10, 8, or 6 players
- drive team assignment and UI counters from `maxPlayers`
- update simulation, touch/tap handlers, and instructions for dynamic player counts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689964813db8832187d9718cd27f63b5