### PR TITLE
feat: add color customization modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <div id="devControls" style="display:none;">
         <button id="btnSim" class="ghost">Simulate 10 (Test)</button>
       </div>
+      <button id="btnSettings">⚙️</button>
     </div>
   </header>
 
@@ -41,6 +42,17 @@
   <div class="panel">
     <div class="stat">Current Fingers: <span id="count" class="counter">0</span> / <span id="maxCount">10</span></div>
     <div class="stat" id="status">Waiting…</div>
+  </div>
+</div>
+
+<div id="settingsModal" class="modal">
+  <div class="modal-content">
+    <label>Offense Color <input type="color" id="offColor"></label>
+    <label>Defense Color <input type="color" id="defColor"></label>
+    <div class="modal-actions">
+      <button id="btnSaveSettings">Save</button>
+      <button id="btnCancelSettings" class="ghost">Cancel</button>
+    </div>
   </div>
 </div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,12 @@
 import { onTouchStart, onTouchMove, onTouchEnd } from './touch-mode.js';
 import { showToast, shuffle, setBadge, createFinger } from './utils.js';
 
+// Apply saved colors before the app initializes
+const savedOFF = localStorage.getItem('colorOFF');
+const savedDEF = localStorage.getItem('colorDEF');
+if (savedOFF) document.documentElement.style.setProperty('--OFF', savedOFF);
+if (savedDEF) document.documentElement.style.setProperty('--DEF', savedDEF);
+
 export class TeamTap {
   constructor() {
     this.OFF_COL = getComputedStyle(document.documentElement).getPropertyValue('--OFF').trim() || '#f5b301';
@@ -142,3 +148,40 @@ export class TeamTap {
 
 const app = new TeamTap();
 app.init();
+
+const btnSettings = document.getElementById('btnSettings');
+const modal = document.getElementById('settingsModal');
+const offInput = document.getElementById('offColor');
+const defInput = document.getElementById('defColor');
+const btnSave = document.getElementById('btnSaveSettings');
+const btnCancel = document.getElementById('btnCancelSettings');
+
+btnSettings.addEventListener('click', () => {
+  offInput.value = app.OFF_COL;
+  defInput.value = app.DEF_COL;
+  modal.style.display = 'flex';
+});
+
+btnCancel.addEventListener('click', () => {
+  modal.style.display = 'none';
+});
+
+btnSave.addEventListener('click', () => {
+  const off = offInput.value;
+  const def = defInput.value;
+  document.documentElement.style.setProperty('--OFF', off);
+  document.documentElement.style.setProperty('--DEF', def);
+  app.OFF_COL = off;
+  app.DEF_COL = def;
+  app.touches.forEach(t => {
+    if (t.role === 'OFF') {
+      t.el.style.background = off;
+    } else if (t.role === 'DEF') {
+      t.el.style.background = def;
+    }
+    setBadge(t, t.role);
+  });
+  localStorage.setItem('colorOFF', off);
+  localStorage.setItem('colorDEF', def);
+  modal.style.display = 'none';
+});

--- a/styles/main.css
+++ b/styles/main.css
@@ -105,3 +105,21 @@
     }
     .badge.off{ background:var(--OFF); color:#201a00; box-shadow: var(--glow-off); }
     .badge.def{ background:var(--DEF); color:#001e12; box-shadow: var(--glow-def); }
+
+    #btnSettings{
+      margin-left:auto;
+      padding:8px 10px;
+      font-size:14px;
+      line-height:1;
+    }
+
+    .modal{
+      position:fixed; inset:0; background:rgba(0,0,0,.7);
+      display:none; align-items:center; justify-content:center;
+    }
+    .modal-content{
+      background:#0d0d18; border:2px solid var(--line); border-radius:10px;
+      padding:20px; display:flex; flex-direction:column; gap:10px; font-size:10px;
+    }
+    .modal-content label{display:flex;align-items:center;justify-content:space-between;gap:10px;}
+    .modal-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:10px;}


### PR DESCRIPTION
## Summary
- add gear button with settings modal for choosing offense/defense colors
- persist chosen colors and apply on startup
- refresh existing finger elements when colors are saved

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c6d831d08321ad578a6f9cc4272c